### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/config.xml
+++ b/app/src/main/res/layout/config.xml
@@ -15,7 +15,7 @@
             android:layout_height="wrap_content"
             android:text="@string/cfg_tvinstruction"
             android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="#0000ff" />
+            android:textColor="#0078FF" />
 
         <Button
             android:id="@+id/savebutton"


### PR DESCRIPTION
The original text color of the component is '#0000FF', and the contrast between the text color ('#0000FF') and the background color ('#000000') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#0078FF') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211373012-71d830c8-63e5-44f5-98fe-dbc436f7757a.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.